### PR TITLE
Add configurable timeout and error logging

### DIFF
--- a/lib/common_graphql_client/caller/http.ex
+++ b/lib/common_graphql_client/caller/http.ex
@@ -12,7 +12,7 @@ if Code.ensure_loaded?(HTTPoison) do
       case HTTPoison.post(client.http_api_url(), body, [{"Content-Type", "application/json"}, {"authorization", "Bearer #{client.http_api_token()}"}]) do
         {:ok, %{body: json_body}} ->
           body = Poison.decode!(json_body)
-          {:ok, body["data"]}
+          {:ok, body["data"], body["errors"]}
         {:error, error} ->
           {:error, error}
       end

--- a/lib/common_graphql_client/caller/websocket.ex
+++ b/lib/common_graphql_client/caller/websocket.ex
@@ -3,10 +3,10 @@ if Code.ensure_loaded?(AbsintheWebSocket) do
     @behaviour CommonGraphQLClient.CallerBehaviour
 
     @impl CommonGraphQLClient.CallerBehaviour
-    def post(client, query, variables \\ []) do
+    def post(client, query, variables \\ [], opts \\ []) do
       query_server_name = Module.concat([client.mod(), Caller, QueryServer])
 
-      AbsintheWebSocket.QueryServer.post(query_server_name, query, variables)
+      AbsintheWebSocket.QueryServer.post(query_server_name, query, variables, opts)
     end
 
     @impl CommonGraphQLClient.CallerBehaviour

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule CommonGraphqlClient.MixProject do
   end
 
   defp aliases do
-    ["publish": ["hex.publish", &git_tag/1]]
+    [publish: ["hex.publish", &git_tag/1]]
   end
 
   defp git_tag(_args) do


### PR DESCRIPTION
Hey - thanks for the very handy libraries. I've added a couple of little features that I found useful:

* Under some circumstances GraphQL can return errors as part of a successful request. These were being silently discarded. I've changed it so that they're at now logged.
* We have one query that can take a little while and was tripping the default 5s `GenServer.call` timeout. I've added the option of specifying a longer timeout.
* Fixed a minor warning in `mix.exs`

There's a companion PR for this over on `absinthe_websocket` which is required to make it all work.