### PR TITLE
Add optional async websocket connection

### DIFF
--- a/lib/common_graphql_client/caller/http.ex
+++ b/lib/common_graphql_client/caller/http.ex
@@ -24,6 +24,6 @@ if Code.ensure_loaded?(HTTPoison) do
     end
 
     @impl CommonGraphQLClient.CallerBehaviour
-    def supervisor(_client), do: nil
+    def supervisor(_client, _opts), do: nil
   end
 end

--- a/lib/common_graphql_client/caller/nil.ex
+++ b/lib/common_graphql_client/caller/nil.ex
@@ -12,5 +12,5 @@ defmodule CommonGraphQLClient.Caller.Nil do
   end
 
   @impl CommonGraphQLClient.CallerBehaviour
-  def supervisor(_client), do: nil
+  def supervisor(_client, _opts), do: nil
 end

--- a/lib/common_graphql_client/caller/websocket.ex
+++ b/lib/common_graphql_client/caller/websocket.ex
@@ -17,10 +17,16 @@ if Code.ensure_loaded?(AbsintheWebSocket) do
     end
 
     @impl CommonGraphQLClient.CallerBehaviour
-    def supervisor(client) do
+    def supervisor(client, opts) do
       base_name = Module.concat([client.mod(), Caller])
 
-      {AbsintheWebSocket.Supervisor, [subscriber: client.mod(), url: client.websocket_api_url(), token: client.websocket_api_token(), base_name: base_name]}
+      {AbsintheWebSocket.Supervisor, [
+        subscriber: client.mod(),
+        url: client.websocket_api_url(),
+        token: client.websocket_api_token(),
+        base_name: base_name,
+        async: Keyword.get(opts, :async, true)
+      ]}
     end
   end
 end

--- a/lib/common_graphql_client/caller_behaviour.ex
+++ b/lib/common_graphql_client/caller_behaviour.ex
@@ -5,6 +5,6 @@ defmodule CommonGraphQLClient.CallerBehaviour do
 
   @callback post(client :: any, query :: String.t(), variables :: keyword()) :: any
   @callback subscribe(client :: any, subscription_name :: atom(), callback :: fun(), query :: String.t(), variables :: keyword()) :: any
-  @callback supervisor(client :: any) :: {atom(), any} | no_return()
+  @callback supervisor(client :: any, opts :: Keyword.t()) :: {atom(), any} | no_return()
 end
 

--- a/lib/common_graphql_client/client.ex
+++ b/lib/common_graphql_client/client.ex
@@ -148,8 +148,8 @@ defmodule CommonGraphQLClient.Client do
         handle_subscribe_to(subscription_name, mod)
       end
 
-      def supervisor() do
-        subscription_caller().supervisor(__MODULE__)
+      def supervisor(opts \\ []) do
+        subscription_caller().supervisor(__MODULE__, opts)
       end
 
       def post(query, variables \\ %{}, opts \\ []) do


### PR DESCRIPTION
This change (and the corresponding one in `absinthe_websocket`) allows the client to specify an `async` connection on the websocket). This fixes a problem where with sending the first message (query or subscirption) before the websocket's `handle_connect` had been triggered, causing the message to arrive at the server before the topic handshake (and so fail).