### PR TITLE
Fix crash in subscription handling

### DIFF
--- a/lib/common_graphql_client/client.ex
+++ b/lib/common_graphql_client/client.ex
@@ -168,7 +168,7 @@ defmodule CommonGraphQLClient.Client do
 
       defp do_subscribe(mod, term, schema, query, variables \\ %{}) do
         callback = fn(result) ->
-          {:ok, resource} = {:ok, result}
+          {:ok, resource} = {:ok, result, nil}
                             |> resolve_response(Atom.to_string(term), schema)
 
           apply(mod, :receive, [term, resource])


### PR DESCRIPTION
Fixes a crash in websocket subscription handling introduced by my earlier error logging changes (oops, sorry).