### PR TITLE
Update Client and HTTP caller to have dynamic config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
 # Changelog
 
-## v.0.5.0
+## v0.6.0
+- [PR 16](https://github.com/annkissam/common_graphql_client/pull/16)
+Dynamic http api token and url support (Breaking change)
+
+## v0.5.0
 - [PR 15](https://github.com/annkissam/common_graphql_client/pull/15) Static Validation for query
 on the client side using npm_graphql
 
-## v.0.3.3
+## v0.3.3
 - [PR 13](`CommonGraphQLClient.Caller.Http.post\4`) Better HTTPoison error handling in `CommonGraphQLClient.Caller.Http.post\4`
 - Allow http_opts to be sent to `CommonGraphQLClient.Caller.Http.post\4`
 
-## v.0.3.2
+## v0.3.2
 - Fix UndefinedFunctionError error on Caller.Http.post & Caller.Nil.post
 
-## v.0.3.1
+## v0.3.1
 - Add configurable timeout and error logging (https://github.com/annkissam/common_graphql_client/pull/9)
 
 ## v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v0.6.0
-- [PR 16](https://github.com/annkissam/common_graphql_client/pull/16)
+- [PR 17](https://github.com/annkissam/common_graphql_client/pull/17)
 Dynamic http api token and url support (Breaking change)
 
 ## v0.5.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ An Elixir libary for generating GraphQL clients. Adapters are provided for both 
 
 This library also supports client-side query validation using `nodejs`.
 
+## Contents
+
+- [Documentation](##-Documentation)
+- [Installation](##-Installation)
+- [Context](##-Context)
+- [Client](##-Client)
+- [Ecto Schemas](##-Ecto-Schemas)
+- [GraphQL Queries](##-GraphQL-Queries)
+- [GraphQL Subscriptions](##-GraphQL-Subscriptions)
+- [Security](##-Security)
+    * [Client](###-Client)
+    * [HTTP Server](###-HTTP-Server)
+    * [WebSocket Server](###-WebSocket-Server)
+- [Client Query Validation](##-Client-Query-Validation)
+    * [Using NPM](###-Using-Npm)
+    * [Using Native Elixir](###-Using-Native-Elixir)
+
+
 ## Documentation
 
 Docs can be found at [https://hexdocs.pm/common_graphql_client](https://hexdocs.pm/common_graphql_client).
@@ -17,7 +35,7 @@ Add `common_graphql_client` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:common_graphql_client, "~> 0.1.0"},
+    {:common_graphql_client, "~> 0.6.0"},
     {:httpoison, "~> 1.1"},            # If using HTTP queries
     {:absinthe_websocket, "~> 0.2.0"}, # If using WebSocket subscriptions (or WebSocket queries)
   ]
@@ -379,7 +397,9 @@ defmodule MyAppWeb.UserSocket do
 end
 ```
 
-## Client-side Query Validation (using schema introspection result)
+## Client Query Validation
+
+- (using schema introspection result)
 
 Query validation can be done at the client-side using schema introspection
 result to get closer to real integration tests without having to run a graphql
@@ -416,13 +436,13 @@ to be available (which is for most of the phoenix development environment)
 For more information on this check out the documentation and examples for
 [`CommonGraphqlClient.StaticValidator.NpmGraphql`](https://hexdocs.pm/common_graphql_client/CommonGraphQLClient.StaticValidator.NpmGraphql.html#content)
 
-### Using npm-graphql
+### Using Npm
 
 This uses `npm` and `node` commands to run schema validation. Make sure you
 have `npm` and `node` installed.
 
 
-### Using native elixir
+### Using Native Elixir
 
 This strategy will use native elixir for performing the validation.
 This is work in progress

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ This library also supports client-side query validation using `nodejs`.
 
 ## Contents
 
-- [Documentation](##-Documentation)
-- [Installation](##-Installation)
-- [Context](##-Context)
-- [Client](##-Client)
-- [Ecto Schemas](##-Ecto-Schemas)
-- [GraphQL Queries](##-GraphQL-Queries)
-- [GraphQL Subscriptions](##-GraphQL-Subscriptions)
-- [Security](##-Security)
-    * [Client](###-Client)
-    * [HTTP Server](###-HTTP-Server)
-    * [WebSocket Server](###-WebSocket-Server)
-- [Client Query Validation](##-Client-Query-Validation)
-    * [Using NPM](###-Using-Npm)
-    * [Using Native Elixir](###-Using-Native-Elixir)
+- [Documentation](##documentation)
+- [Installation](##Installation)
+- [Context](##Context)
+- [Client](##Client)
+- [Ecto Schemas](##Ecto-Schemas)
+- [GraphQL Queries](##GraphQL-Queries)
+- [GraphQL Subscriptions](##GraphQL-Subscriptions)
+- [Security](##Security)
+    * [Client](###Client)
+    * [HTTP Server](###HTTP-Server)
+    * [WebSocket Server](###WebSocket-Server)
+- [Client Query Validation](##Client-Query-Validation)
+    * [Using NPM](###Using-Npm)
+    * [Using Native Elixir](###Using-Native-Elixir)
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ This library also supports client-side query validation using `nodejs`.
 
 ## Contents
 
-- [Documentation](##documentation)
-- [Installation](##Installation)
-- [Context](##Context)
-- [Client](##Client)
-- [Ecto Schemas](##Ecto-Schemas)
-- [GraphQL Queries](##GraphQL-Queries)
-- [GraphQL Subscriptions](##GraphQL-Subscriptions)
-- [Security](##Security)
-    * [Client](###Client)
-    * [HTTP Server](###HTTP-Server)
-    * [WebSocket Server](###WebSocket-Server)
-- [Client Query Validation](##Client-Query-Validation)
-    * [Using NPM](###Using-Npm)
-    * [Using Native Elixir](###Using-Native-Elixir)
+- [Documentation](#documentation)
+- [Installation](#Installation)
+- [Context](#Context)
+- [Client](#Client)
+- [Ecto Schemas](#Ecto-Schemas)
+- [GraphQL Queries](#GraphQL-Queries)
+- [GraphQL Subscriptions](#GraphQL-Subscriptions)
+- [Security](#Security)
+    * [Client Security](#Client-Security)
+    * [HTTP Server](#HTTP-Server)
+    * [WebSocket Server](#WebSocket-Server)
+- [Client Query Validation](#Client-Query-Validation)
+    * [Using NPM](#Using-Npm)
+    * [Using Native Elixir](#Using-Native-Elixir)
 
 
 ## Documentation
@@ -279,7 +279,7 @@ end
 
 ## Security
 
-### Client
+### Client Security
 
 The HTTP Client can send `Bearer` tokens, whereas the WebSocket can send a token as a query param. Since these credentials should not be in source control, this library provides a way to set them at runtime. First, update the Mix config:
 

--- a/lib/common_graphql_client/caller/http.ex
+++ b/lib/common_graphql_client/caller/http.ex
@@ -14,11 +14,11 @@ if Code.ensure_loaded?(HTTPoison) do
         |> Poison.encode!()
 
       case HTTPoison.post(
-             client.http_api_url(),
+             client.http_api_url(opts),
              body,
              [
                {"Content-Type", "application/json"},
-               {"authorization", "Bearer #{client.http_api_token()}"}
+               {"authorization", "Bearer #{client.http_api_token(opts)}"}
              ],
              Keyword.get(opts, :http_opts, [])
            ) do

--- a/lib/common_graphql_client/caller/websocket.ex
+++ b/lib/common_graphql_client/caller/websocket.ex
@@ -31,8 +31,8 @@ if Code.ensure_loaded?(AbsintheWebSocket) do
       {AbsintheWebSocket.Supervisor,
        [
          subscriber: client.mod(),
-         url: client.websocket_api_url(),
-         token: client.websocket_api_token(),
+         url: client.websocket_api_url(opts),
+         token: client.websocket_api_token(opts),
          base_name: base_name,
          async: Keyword.get(opts, :async, true)
        ]}

--- a/lib/common_graphql_client/client.ex
+++ b/lib/common_graphql_client/client.ex
@@ -72,19 +72,19 @@ defmodule CommonGraphQLClient.Client do
         end
       end
 
-      def http_api_token do
+      def http_api_token(_opts \\ []) do
         config(:http_api_token)
       end
 
-      def http_api_url do
+      def http_api_url(_opts \\ []) do
         config(:http_api_url)
       end
 
-      def websocket_api_token do
+      def websocket_api_token(_opts \\ []) do
         config(:websocket_api_token)
       end
 
-      def websocket_api_url do
+      def websocket_api_url(_opts \\ []) do
         config(:websocket_api_url)
       end
 
@@ -235,8 +235,10 @@ defmodule CommonGraphQLClient.Client do
       defoverridable handle: 2,
                      handle: 3,
                      handle_subscribe_to: 2,
-                     http_api_token: 0,
-                     websocket_api_token: 0
+                     http_api_token: 1,
+                     http_api_url: 1,
+                     websocket_api_token: 1,
+                     websocket_api_url: 1
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CommonGraphqlClient.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.6.0"
   @url "https://github.com/annkissam/common_graphql_client"
   @maintainers [
     "Josh Adams",


### PR DESCRIPTION
Updates client to have overridable `http_api_token` and `http_api_url` methods. In this way, we won't have to specify it at module definition while giving us the ability to determine the token and url based on options.

Bumps version to `0.6.0`

Adds anchor links to `README.md`. It was getting too long.